### PR TITLE
Fixed adding new user, that was blocked by missing Login sessions.

### DIFF
--- a/flux/templates/edit_user.html
+++ b/flux/templates/edit_user.html
@@ -63,7 +63,7 @@
     {% endif %}
   </form>
 
-  {% if cuser.id == request.user.id or request.user.can_manage %}
+  {% if not is_new and (cuser.id == request.user.id or request.user.can_manage) %}
     <h2>Login Sessions</h2>
     {% for token in cuser.login_tokens.order_by('lambda x: desc(x.created)') %}
       <div class="login-session{{ ' expired' if token.expired() else ''}}">


### PR DESCRIPTION
I've currently found out, that application throws Internal Server Error on create new user due to undefined list of sessions (for non-existing user).
This PR only adds condition to render sessions only for already existing users on edit_user.html template.