### PR TITLE
Added setting, that defines, at which point should be .git removed.

### DIFF
--- a/flux/build.py
+++ b/flux/build.py
@@ -24,6 +24,7 @@ that will process the queue.
 '''
 
 from flux import app, config, utils, models
+from flux.enums import GitFolderHandling
 from flux.models import select, Build
 from collections import deque
 from threading import Event, Condition, Thread
@@ -279,7 +280,7 @@ def do_build_(build, build_path, override_path, logger, logfile, terminate_event
     return False
 
   # Deletes .git folder before build, if is configured so.
-  if config.git_folder_handling == config.GitFolderHandling.DELETE_BEFORE_BUILD or config.git_folder_handling == None:
+  if config.git_folder_handling == GitFolderHandling.DELETE_BEFORE_BUILD or config.git_folder_handling == None:
     logger.info('[Flux]: removing .git folder before build')
     deleteGitFolder(build_path)
 
@@ -322,7 +323,7 @@ def do_build_(build, build_path, override_path, logger, logfile, terminate_event
     return False
 
   # Deletes .git folder after build, if is configured so.
-  if config.git_folder_handling == config.GitFolderHandling.DELETE_AFTER_BUILD:
+  if config.git_folder_handling == GitFolderHandling.DELETE_AFTER_BUILD:
     logger.info('[Flux]: removing .git folder after build')
     deleteGitFolder(build_path)
 

--- a/flux/build.py
+++ b/flux/build.py
@@ -144,6 +144,8 @@ def update_queue(consumer=None):
       if not consumer.is_running(build):
         build.status = Build.Status_Stopped
 
+def deleteGitFolder(build_path):
+  shutil.rmtree(os.path.join(build_path, '.git'))
 
 def do_build(build_id, terminate_event):
   """
@@ -276,8 +278,10 @@ def do_build_(build, build_path, override_path, logger, logfile, terminate_event
     logger.info('[Flux]: build stopped')
     return False
 
-  # Delete the .git folder to save space. We don't need it anymore.
-  utils.rmtree(os.path.join(build_path, '.git'), remove_write_protection=True)
+  # Deletes .git folder before build, if is configured so.
+  if config.git_folder_handling == config.GitFolderHandling.DELETE_BEFORE_BUILD or config.git_folder_handling == None:
+    logger.info('[Flux]: removing .git folder before build')
+    deleteGitFolder(build_path)
 
   # Copy over overridden files if any
   if os.path.exists(override_path):
@@ -316,6 +320,11 @@ def do_build_(build, build_path, override_path, logger, logfile, terminate_event
       logger.exception(exc)
     logger.error('[Flux]: build stopped. build script terminated')
     return False
+
+  # Deletes .git folder after build, if is configured so.
+  if config.git_folder_handling == config.GitFolderHandling.DELETE_AFTER_BUILD:
+    logger.info('[Flux]: removing .git folder after build')
+    deleteGitFolder(build_path)
 
   logger.info('[Flux]: exit-code {}'.format(popen.returncode))
   return popen.returncode == 0

--- a/flux/enums.py
+++ b/flux/enums.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class GitFolderHandling(Enum):
+  """
+  This enum defines way, how is .git folder handled during project build.
+  """
+  DELETE_BEFORE_BUILD = 1
+  DELETE_AFTER_BUILD = 2
+  DISABLE_DELETE = 3

--- a/flux_config.py
+++ b/flux_config.py
@@ -3,6 +3,7 @@ This is the Flux configuration file.
 '''
 
 import os
+from enum import Enum
 from datetime import timedelta
 from flux.config import prepend_path
 
@@ -12,6 +13,11 @@ from flux.config import prepend_path
 ## the next line and adjust path to update the PATH environment variable
 ## so flux can find the newer Git version.
 # prepend_path('~/git')
+
+class GitFolderHandling(Enum):
+  DELETE_BEFORE_BUILD = 1
+  DELETE_AFTER_BUILD = 2
+  DISABLE_DELETE = 3
 
 ## Root directory where the flux data is stored, repositories are checked
 ## out and built. Defaults to the flux application directory.
@@ -106,3 +112,9 @@ ssh_verbose = False
 ## The time that a login token should be valid for. Specify "None" to
 ## prevent login tokens from expiring.
 login_token_duration = timedelta(hours=6)
+
+## Defines, how .git folder should be handled during build process, it uses values from GitFolderHandling enum:
+## * DELETE_BEFORE_BUILD - Native behaviour, that deletes .git folder before .flux-build runs.
+## * DELETE_AFTER_BUILD - Deletes .git folder after .flux-build successfully runs, before artifact is zipped.
+## * DISABLE_DELETE - .git folder is never deleted, it will be part of artifact ZIP.
+git_folder_handling = GitFolderHandling.DELETE_BEFORE_BUILD

--- a/flux_config.py
+++ b/flux_config.py
@@ -3,9 +3,9 @@ This is the Flux configuration file.
 '''
 
 import os
-from enum import Enum
 from datetime import timedelta
 from flux.config import prepend_path
+from flux.enums import GitFolderHandling
 
 ## If your system does not provide the required Git version (>= 2.3),
 ## you can compile it by yourself and install it locally (or not install
@@ -13,11 +13,6 @@ from flux.config import prepend_path
 ## the next line and adjust path to update the PATH environment variable
 ## so flux can find the newer Git version.
 # prepend_path('~/git')
-
-class GitFolderHandling(Enum):
-  DELETE_BEFORE_BUILD = 1
-  DELETE_AFTER_BUILD = 2
-  DISABLE_DELETE = 3
 
 ## Root directory where the flux data is stored, repositories are checked
 ## out and built. Defaults to the flux application directory.


### PR DESCRIPTION
Last year I had mentioned, that in some cases it could be required to have .git folder during build (e.g. enhancing application version). For this specific reason I've added new configuration named `git_folder_handling`.
This config could be set to three options:
- **DELETE_BEFORE_BUILD** - the default option, that removes .git folder before build starts. This is original behaviour.
- **DELETE_AFTER_BUILD** - this option covers mentioned state, when .git folder is available during build, but is removed before zipped artifact is created.
- **DISABLE_DELETE** - the option, that leaves .git folder at project during build and also is zipped to artifact.