### PR TITLE
Fixed link and application name in footer.

### DIFF
--- a/flux/templates/base.html
+++ b/flux/templates/base.html
@@ -105,7 +105,7 @@
     </main>
     <footer>
       <div class="container">
-        Powered by <a href="https://github.com/NiklasRosenstein/flux">Flux</a> v{{ flux.__version__ }}
+        Powered by <a href="https://github.com/NiklasRosenstein/flux-ci">Flux CI</a> v{{ flux.__version__ }}
       </div>
     </footer>
   </body>


### PR DESCRIPTION
Fixed link and application name in footer of base template to be up to date. It should also prevent potentional issue with disabled redirect from old URL of repo.