### PR TITLE
Fixed secret column in Repository model to be optional.

### DIFF
--- a/flux/models.py
+++ b/flux/models.py
@@ -129,7 +129,7 @@ class Repository(db.Entity):
 
   id = orm.PrimaryKey(int)
   name = orm.Required(str)
-  secret = orm.Required(str)
+  secret = orm.Optional(str)
   clone_url = orm.Required(str)
   build_count = orm.Required(int, default=0)
   builds = orm.Set('Build')


### PR DESCRIPTION
Column secret used to be optional in Repository model before the ORM change, this caused an issue with using Bitbucket Cloud or any other repository, that does not use secret key. 