### PR TITLE
Fix usage of automatically generated repository SSH keypair

### DIFF
--- a/flux/file_utils.py
+++ b/flux/file_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf8 -*-
 
+import io
 import os
 import shutil
 
@@ -126,7 +127,7 @@ def read_file(path):
   return ''
 
 
-def write_file(path, data):
+def write_file(path, data, encoding='utf8'):
   """
   Writes *data* into file located in *path*, only if it already exists.
   As workaround, it replaces \r symbol.
@@ -137,7 +138,7 @@ def write_file(path, data):
   """
 
   if os.path.isfile(path):
-    file = open(path, mode='w')
+    file = io.open(path, mode='w', encoding=encoding)
     file.write(data.replace('\r', ''))
     file.close()
 

--- a/flux/utils.py
+++ b/flux/utils.py
@@ -363,7 +363,10 @@ def ssh_command(url, *args, no_ptty=False, identity_file=None,
   if no_ptty:
     command.append('-T')
   if identity_file:
-    command += ['-i', identity_file]
+    command += ['-o', 'IdentitiesOnly=yes']
+    # NOTE: Workaround for windows, as the backslashes are gone at the time
+    #   Git tries to use the GIT_SSH_COMMAND.
+    command += ['-i', identity_file.replace('\\', '/')]
   if verbose:
     command.append('-v')
   if args:

--- a/flux/utils.py
+++ b/flux/utils.py
@@ -493,7 +493,7 @@ def get_public_key():
   return None
 
 
-def generate_ssh_keypair():
+def generate_ssh_keypair(public_key_comment):
   """
   Generates new RSA ssh keypair.
 
@@ -502,8 +502,11 @@ def generate_ssh_keypair():
   """
 
   key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=4096)
-  private_key = key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption())
-  public_key = key.public_key().public_bytes(serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH)
+  private_key = key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()).decode('ascii')
+  public_key = key.public_key().public_bytes(serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH).decode('ascii')
+
+  if public_key_comment:
+    public_key += ' ' + public_key_comment
 
   return private_key, public_key
 

--- a/flux/views.py
+++ b/flux/views.py
@@ -310,7 +310,7 @@ def generate_keypair(path):
   utils.makedirs(utils.get_customs_path(repo))
 
   try:
-    private_key, public_key = utils.generate_ssh_keypair()
+    private_key, public_key = utils.generate_ssh_keypair(repo.name + '@FluxCI')
     private_key_path = utils.get_repo_private_key_path(repo)
     public_key_path = utils.get_repo_public_key_path(repo)
 
@@ -318,8 +318,8 @@ def generate_keypair(path):
       file_utils.create_file_path(private_key_path)
       file_utils.create_file_path(public_key_path)
 
-      file_utils.write_file(private_key_path, private_key.decode())
-      file_utils.write_file(public_key_path, public_key.decode())
+      file_utils.write_file(private_key_path, private_key)
+      file_utils.write_file(public_key_path, public_key)
 
       try:
         os.chmod(private_key_path, 0o600)


### PR DESCRIPTION
* Ensure that _only_ the repo's generated identity file is used (or _only_ the server's configured identitity file otherwise)
* Work around a problem on Windows where Git executes `GIT_SSH_COMMAND` without backslahes (probably an escaping issue, the workaround is to convert backslashes to normal slashes)